### PR TITLE
Feature/96 vat id validation adjustment

### DIFF
--- a/edevis/edevis/custom/customer.json
+++ b/edevis/edevis/custom/customer.json
@@ -1320,7 +1320,7 @@
    "property": "default",
    "property_type": "Text",
    "row_name": null,
-   "value": "30 Tage netto"
+   "value": ""
   },
   {
    "_assign": null,

--- a/edevis/edevis/custom/customer.json
+++ b/edevis/edevis/custom/customer.json
@@ -373,7 +373,7 @@
    "print_hide": 0,
    "print_hide_if_no_value": 0,
    "print_width": null,
-   "read_only": 0,
+   "read_only": 1,
    "read_only_depends_on": "",
    "report_hide": 0,
    "reqd": 0,

--- a/edevis/fixtures/property_setter.json
+++ b/edevis/fixtures/property_setter.json
@@ -1,0 +1,18 @@
+[
+ {
+  "default_value": null,
+  "doc_type": "Customer",
+  "docstatus": 0,
+  "doctype": "Property Setter",
+  "doctype_or_field": "DocField",
+  "field_name": "tax_category",
+  "is_system_generated": 0,
+  "modified": "2025-01-22 11:28:51.466229",
+  "module": "Edevis",
+  "name": "Customer-tax_category-reqd",
+  "property": "reqd",
+  "property_type": "Check",
+  "row_name": null,
+  "value": "1"
+ }
+]

--- a/edevis/hooks.py
+++ b/edevis/hooks.py
@@ -170,6 +170,11 @@ fixtures = [
     {
 		"doctype": "Workflow Action"
     },
+    {"dt": "Property Setter", "filters": [
+        [
+            "module", "=", "Edevis"
+        ]
+    ]}, 
     {"dt": "Role", "filters": [
         [
             "name", "in", [
@@ -220,7 +225,7 @@ fixtures = [
                     "Section End"
             ]
         ]
-    ]}
+    ]},
 ]
 # Scheduled Tasks
 # ---------------


### PR DESCRIPTION
https://git.phamos.eu/edevis/edevis/-/issues/96

Changed fields in the tax tab for customer:

![image](https://github.com/user-attachments/assets/d8ed6c62-4e58-42e1-9482-a3ef66dcf2c9)

Also fixed a little bug where "value": "30 Tage netto" can throw an error


