### PR TITLE
description removed from booking report

### DIFF
--- a/edevis/edevis/report/edevis_booking/edevis_booking.py
+++ b/edevis/edevis/report/edevis_booking/edevis_booking.py
@@ -55,7 +55,7 @@ def get_columns():
 def get_data(filters):
     conditions = get_conditions(filters)
 
-    return frappe.db.sql(
+    raw_data = frappe.db.sql(
         f"""
         SELECT 
             si.posting_date,
@@ -78,6 +78,15 @@ def get_data(filters):
         filters,
         as_dict=True
     )
+
+    for row in raw_data:
+        if row.get("debit_to"):
+            row["debit_to"] = row["debit_to"].split(" - ")[0]
+        if row.get("income_account"):
+            row["income_account"] = row["income_account"].split(" - ")[0]
+
+    return raw_data
+
 
 
 def get_conditions(filters):


### PR DESCRIPTION
**Description:**

- Description removed from the account (debit_to and income_Account).
- Only the account no is now shown in the report.

Issue: In edevis booking report only show account numbers (#186)
Parent Issue: https://git.phamos.eu/edevis/edevis/-/issues/186

Screenshot:

![image](https://github.com/user-attachments/assets/326b0eee-46ae-46aa-9d96-c993697b08dc)
