### PR TITLE
edevis/edevis#229: updated autoname

### DIFF
--- a/edevis/fixtures/property_setter.json
+++ b/edevis/fixtures/property_setter.json
@@ -366,5 +366,37 @@
   "property_type": "Check",
   "row_name": null,
   "value": "1"
- }
+ },
+ {
+    "default_value": null,
+    "doc_type": "Serial No",
+    "docstatus": 0,
+    "doctype": "Property Setter",
+    "doctype_or_field": "DocType",
+    "field_name": null,
+    "is_system_generated": 0,
+    "modified": "2025-09-17 11:15:47.675875",
+    "module": "Edevis",
+    "name": "Serial No-main-naming_rule",
+    "property": "naming_rule",
+    "property_type": "Data",
+    "row_name": null,
+    "value": ""
+   },
+   {
+    "default_value": null,
+    "doc_type": "Serial No",
+    "docstatus": 0,
+    "doctype": "Property Setter",
+    "doctype_or_field": "DocType",
+    "field_name": null,
+    "is_system_generated": 0,
+    "modified": "2025-09-17 11:16:05.438107",
+    "module": "Edevis",
+    "name": "Serial No-main-autoname",
+    "property": "autoname",
+    "property_type": "Data",
+    "row_name": null,
+    "value": ""
+   }
 ]


### PR DESCRIPTION
Issue: https://git.phamos.eu/edevis/edevis/-/work_items/229
Parent: https://git.phamos.eu/edevis/edevis/-/issues/228

SUmmary: reset defaut autoname for Serial No.